### PR TITLE
[bug] setup does only work with msvc compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,10 +192,13 @@ class MyBuildExt(build_ext):
                 ext.define_macros.append(("inline", "__inline"))
 
                 # Configure the linker
-                ext.extra_link_args.append("libeay32.lib")
-                ext.extra_link_args.append(
-                    "/LIBPATH:" + os.path.join(openssl, "lib")
-                )
+                if self.compiler.compiler_type == "msvc":
+                    ext.extra_link_args.append("libeay32.lib")
+                    ext.extra_link_args.append(
+                        "/LIBPATH:" + os.path.join(openssl, "lib")
+                    )
+                if self.compiler.compiler_type == "mingw32":
+                    ext.extra_link_args.append("-lcrypto")     
             else:
                 ext.extra_link_args.append("-lcrypto")
 


### PR DESCRIPTION
add compiler detection for msvc & mingw32, will fail on win32 with mingw otherwise (/LIBPATH is msvc only)
